### PR TITLE
swap docstrings for resampling and bias correction

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+Current
+-------
+* Fix docstrings for resampling and bias correction of Temp for projection
+
 v0.4.0
 ------
 * Separate out ``resample_ics`` and ``bias_correct_temps`` into two functions.

--- a/pySESL/project.py
+++ b/pySESL/project.py
@@ -102,8 +102,8 @@ def get_ics(n_fair_sims, sesl_trained_params, sesl_hyperparams, sesl_input_dir):
 
 
 def resample_ics(ics, sim_ids, sesl_trained_params):
-    """Bias correct a temperature dataset such that it matches with the reference period
-    used to calculate the T0_2000 initial condition.
+    """Resample ICs such that they have the same number of samples as are in the
+    temperature projections ``temps``.
 
     TODO: finish docstring
     """
@@ -133,10 +133,10 @@ def resample_ics(ics, sim_ids, sesl_trained_params):
     out_params = xr.merge((T0_2000, c_2000, T_ref, param_sims))
     return out_params
 
-  
+
 def bias_correct_temps(temps, bc_period, T_ref, first_year=None):
-    """Resample ICs such that they have the same number of samples as are in the
-    temperature projections ``temps``.
+    """Bias correct a temperature dataset such that it matches with the reference period
+    used to calculate the T0_2000 initial condition.
 
     TODO: finish docstring
     """


### PR DESCRIPTION
These were accidentally in swapped when the resampling and bias correction function was decomposed into two separate funcs.